### PR TITLE
Add .gitattributes file to attempt to fix the Github linguist classification of this repository as HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.pdf linguist-generated
+*.html linguist-generated
+*.ipynb linguist-documentation
+*.svg -linguist-detectable


### PR DESCRIPTION
Based on https://github.com/github-linguist/linguist/blob/c959cb53f48552db0e42cded66f3e5a64749b9ec/docs/overrides.md?plain=1#L7 .

Note this may not trigger an update to the Github language statistics for this repository for a while (see https://github.com/github-linguist/linguist/blob/c959cb53f48552db0e42cded66f3e5a64749b9ec/docs/how-linguist-works.md?plain=1#L29 ).